### PR TITLE
Download model weights from Replicate cache, accept MP3 and WAV inputs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
+
+output.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .cog
 .cache
+models

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an implementation of [WhisperSpeech](https://github.com/collabora/Whispe
 
 ## Development
 
-Follow the [model pushing guide](https://replicate.com/docs/guides/push-a-model) to push your own fork of SDXL to [Replicate](https://replicate.com).
+Follow the [model pushing guide](https://replicate.com/docs/guides/push-a-model) to push your own model to [Replicate](https://replicate.com).
 
 ## Basic Usage
 

--- a/cog.yaml
+++ b/cog.yaml
@@ -11,5 +11,9 @@ build:
   system_packages:
     - "ffmpeg"
 
+  run:
+    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.5.6/pget_linux_x86_64" && chmod +x /usr/local/bin/pget
+
+
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/cog.yaml
+++ b/cog.yaml
@@ -8,5 +8,8 @@ build:
     - "torch==2.0.1"
     - "WhisperSpeech==0.5.6"
 
+  system_packages:
+    - "ffmpeg"
+
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -52,7 +52,7 @@ class Predictor(BasePredictor):
             choices=["en", "pl"]
         ),
         speaker: str = Input(
-            description="URL of an OGG audio file for zero-shot voice cloning. (ex: https://upload.wikimedia.org/wikipedia/commons/7/75/Winston_Churchill_-_Be_Ye_Men_of_Valour.ogg)",
+            description="URL of an audio file for zero-shot voice cloning. Supported audio formats are OGG, WAV and MP3. (example: https://upload.wikimedia.org/wikipedia/commons/7/75/Winston_Churchill_-_Be_Ye_Men_of_Valour.ogg)",
             default="",
         ),
     ) -> Path:


### PR DESCRIPTION
Results of reviewing whisper-speech:
- model now accepts mp3 and wav files
- cog image now downloads weights from Replicate's weights bucket, and stores all weights in /src/models
- slightly clarified the readme
